### PR TITLE
Make RSS `guid isPermaLink=true`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -94,7 +94,6 @@ module.exports = {
                   description: edge.node.excerpt,
                   date: edge.node.frontmatter.date,
                   url: site.siteMetadata.siteUrl + edge.node.fields.slug,
-                  guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
                   custom_elements: [{ "content:encoded": edge.node.html }],
                 })
               })


### PR DESCRIPTION
Remove custom `guid` definition to use the built-in one, which uses the value from the `url` field anyway, and also sets `isPermaLink=true`.